### PR TITLE
Update stats

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ on:
   workflow_dispatch:
   push:
     branches: main
+  schedule:
+    ## Run once an hour
+    - cron:  '0 * * * *'
 
 name: Quarto Publish
 

--- a/cran-archiving-stats.qmd
+++ b/cran-archiving-stats.qmd
@@ -15,12 +15,6 @@ knitr::opts_chunk$set(
 
 ```{r, echo = FALSE}
 library("dplyr")
-logic2string <- function(x){
-  y <- NA
-  y[x] <- "yes"
-  y[!x] <- "no"
-  y
-}
 url <- "https://cran.r-project.org/src/contrib/PACKAGES.in"
 con <- url(url)
 file <- read.dcf(con) |> 
@@ -30,17 +24,17 @@ file <- read.dcf(con) |>
 comments_l <- lapply(file$`X-CRAN-Comment`, function(x) {
   unlist(strsplit(x, "[\n]+"), FALSE, FALSE)
 })
-comments_c <- unlist(comments_l)
+comments_c <- unlist(comments_l, FALSE, FALSE)
 df <- data.frame(package = rep(file$Package, lengths(comments_l)),
-           comment = comments_c)
+                 comment = comments_c)
 regex_date <- "([0-9]{4}-[0-9]{2}-[0-9]{2})"
 regex_action <- "([Uu]narchived?|[Aa]rchived?|[Rr]enamed?|[Oo]rphaned?|[Rr]eplaced?|[Rr]emoved?)"
 comments_df <- cbind(df, 
-           strcapture(pattern = regex_date, x = df$comment, 
-                      proto = data.frame(date = Sys.Date()[0])),
-           strcapture(pattern = regex_action, x = df$comment,
-                      proto = data.frame(action = character()))
-           ) |> 
+                     strcapture(pattern = regex_date, x = df$comment, 
+                                proto = data.frame(date = Sys.Date()[0])),
+                     strcapture(pattern = regex_action, x = df$comment,
+                                proto = data.frame(action = character()))
+) |> 
   filter(!is.na(comment)) |> 
   mutate(action = tolower(action))
 # Check that count(comments_df, !is.na(date), !is.na(action), sort = TRUE) makes sense
@@ -56,7 +50,7 @@ history_l <- lapply(file$`X-CRAN-History`, function(x) {
 history_c <- unlist(history_l)
 
 history_df <- data.frame(package = rep(file$Package, lengths(history_l)),
-                    comment = history_c) |> 
+                         comment = history_c) |> 
   filter(!is.na(comment))
 
 history_df <- cbind(history_df,
@@ -64,18 +58,18 @@ history_df <- cbind(history_df,
                                proto = data.frame(date = Sys.Date()[0])),
                     strcapture(pattern = regex_action, x = history_df$comment,
                                proto = data.frame(action = character()))
-           ) |> 
+) |> 
   mutate(action = tolower(action))
 history_df$action[grep("Back on CRAN", history_df$comment, ignore.case = TRUE)] <- "unarchived"
-library("reactable")
-history <- rbind(comments_df, history_df) |> 
+
+full_history <- rbind(comments_df, history_df) |> 
   mutate(action = gsub(pattern = "e$", replacement = "ed", action)) |> 
   arrange(package) |>
   relocate(date) |>
-  relocate(comment, .after = last_col()) |>
-  filter(action %in% c("archived", "unarchived"),
-         !is.na(date),
-         !is.na(action)) 
+  relocate(comment, .after = last_col())
+history <- filter(full_history, action %in% c("archived", "unarchived"),
+                  !is.na(date),
+                  !is.na(action)) 
 ```
 
 ```{r, echo = FALSE}
@@ -116,6 +110,7 @@ void <- out |>
             n_archive = sum(action == "archived"),
             k = any(date[action == "unarchive"] != date[action == "new"])) |> 
   filter(k)
+stopifnot(NROW(void) == 0L)
 ```
 
 ```{r, echo = FALSE}
@@ -139,9 +134,9 @@ more <- out |>
          lag = lag(action, default = NA)) |> 
   filter((action == "archived" & lead == "new") | 
            (action == "new" & lag == "archived")) |>
-  mutate(times_archived = rep(1:9, each = 2, length.out = n())) |> 
+  mutate(times_archived = rep(1:n(), each = 2, length.out = n())) |> 
   ungroup()
-  
+
 library("tidyr")
 pw <- more |> 
   select(package, times_archived, action, date) |> 
@@ -170,7 +165,7 @@ pw |> summarise(.by = times_archived,
                 min = min(timediff), 
                 q1 = quantile(timediff, 0.25), 
                 mean = mean(timediff), 
-                m = median(timediff), 
+                mdeian = median(timediff), 
                 q3 = quantile(timediff, 0.75), 
                 max = max(timediff)) |> 
   mutate(across(where(fiu), round)) |> 
@@ -186,20 +181,44 @@ pw |>
   filter(times_archived == "1") |> 
   ggplot() +
   stat_ecdf(aes(timediff)) +
-  coord_cartesian(xlim =  c(0, 365))
+  coord_cartesian(xlim =  c(0, 365), expand = FALSE) +
+  scale_y_continuous(labels = scales::label_percent()) +
+  scale_x_continuous(breaks = 30*1:12) +
+  theme_minimal() +
+  labs(title = "Time for packages to be back on CRAN for the first time",
+       subtitle = "Focusing in packages in less than a year",
+       y = "Percentage of packages back on CRAN",
+       x = "Days till packages are back on CRAN")
+
 ```
 
 
 ### Cumulative number of archived packages over the years
 
 ```{r}
-pw |> 
-  arrange(archived) |> 
-  mutate(n = cumsum(seq_len(n()))) |> 
+library("patchwork")
+p <- full_history |> 
+  filter(!is.na(action), !is.na(date)) |> 
+  arrange(date) |> 
+  select(-comment) |> 
+  group_by(action) |> 
+  mutate(n = seq_len(n())) |> 
+  ungroup() |> 
   ggplot() +
-  geom_line(aes(archived, n)) +
+  geom_line(aes(date, n, col = action, linetype = action)) +
+  scale_x_date(date_breaks = "2 year", date_labels = "%Y",
+               expand = expansion()) +
   theme_minimal() +
-  scale_y_log10(guide = "axis_logticks")
+  labs(x = "Date of the archive",
+       y = "Total number of packages"
+  )
+p + scale_y_continuous(expand = expansion()) + 
+  p + scale_y_log10(guide = "axis_logticks", expand = expansion()) +
+  plot_annotation(
+    title = "Accumulation of actions on pacakges",
+  ) +
+  plot_layout(guides = 'collect', axes = "collect") &
+  theme(legend.position='bottom')
 ```
 
 
@@ -217,7 +236,7 @@ pw |>
   scale_y_continuous(expand = expansion(c(0, NA), c(0, NA))) +
   labs(x = "Date when the package was archived",
        y = "Time until it went back to CRAN",
-       title = "Time till packages are back to CRAN")
+       title = "Time till archived packages are back to CRAN")
 ```
 
 


### PR DESCRIPTION
This PR improves some problems with the plots provided.
Specifically the "Cumulative number of archived packages over the years" only used data from packages that were both archived and unarchived, I have fixed this using the full file (and all the actions identified). 

I didn't update the code chunks but I think it would be better if they were updated to match.
The plots also lack some text introducing them, alt-text or figure legend so that they can be interpreted more easily. I'll be happy to add those.