### PR TITLE
Remove NA links created from empty BugReports field

### DIFF
--- a/dashboard-at-risk.qmd
+++ b/dashboard-at-risk.qmd
@@ -108,7 +108,7 @@ atrisk$Links <- sprintf('<a href="https://cran.r-project.org/web/checks/check_re
 urls <- vapply(strsplit(atrisk$URL, split = ",\\s+|\\s+"), function(x){x[1]}, FUN.VALUE = character(1))
 atrisk$Links <- sprintf('%s<br><a href="%s">url</a>', atrisk$Links, urls)
 atrisk$Links <- sprintf('%s<br><a href="%s">url2</a>', atrisk$Links, atrisk$BugReports)
-atrisk$Links <- gsub('<br><a href="NA">url</a>', "", atrisk$Links)
+atrisk$Links <- gsub('<br><a href="NA">url2?</a>', "", atrisk$Links)
 atrisk$URL <- NULL
 atrisk$BugReports <- NULL
 revdeps <- atrisk[["Reverse Packages"]]


### PR DESCRIPTION
Currently, packages with an empty `BugReports` fields with have a https://www.cranhaven.org/NA link under `url2` (see for example the typr package right now).

One way to avoid this would be to add a code branch checking whether `BugReports` is empty or not before adding it to `Links`.

But the code is currently just letting these URLs be created and then removes them for empty `URL` so I have extended the regexp to apply the same logic to empty `BugReports` field.